### PR TITLE
spelling fix: thre -> three

### DIFF
--- a/basic.rst
+++ b/basic.rst
@@ -156,7 +156,7 @@ From the `Go Programming Language Specification`_
     var x, y, z = 1, 2, 3 //type omitted, variables initialized
     func test(){
         var pi  float32 //basic form
-        one, two, thre := 1, 2, 3 //type and var omitted, variables initialized
+        one, two, three := 1, 2, 3 //type and var omitted, variables initialized
         c := 10+3i // a complex number, type infered and keyword 'var' omitted.
         pi = 3.14 // normal assignation
     }


### PR DESCRIPTION
(not sure if this was intentional or not)
